### PR TITLE
Add class to the comments link in the category view

### DIFF
--- a/plugins/content/slicomments/slicomments.php
+++ b/plugins/content/slicomments/slicomments.php
@@ -37,7 +37,7 @@ class plgContentSlicomments extends JPlugin
 			$model->setState('article.id', $row->id);
 			$total = $model->getTotal();
 			if (($total > 0 || $attribs->get('slicomments.enabled', true)) && $model->isCategoryEnabled($row->catid)) {
-				return '<a href="'.JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid)).'#comments">'.JText::sprintf('PLG_CONTENT_SLICOMMENTS_COMMENTS_COUNT', $total).'</a>';
+				return '<a href="'.JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid)).'#comments" class="comments-link">'.JText::sprintf('PLG_CONTENT_SLICOMMENTS_COMMENTS_COUNT', $total).'</a>';
 			}
 		}
 		elseif ($view == 'article')


### PR DESCRIPTION
Hi,
the link that can be appended on every item in the category view has no class attribute. Therefore you can hardly modify the link through css.

A class for this link would be really awesome.

Nevertheless, please keep up working on this great extension :-)
